### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.games-website
+++ b/Dockerfile.games-website
@@ -1,0 +1,13 @@
+FROM php:7.4-apache
+
+# Copy source code to /var/www/html
+COPY _build/src/ /var/www/html/
+
+# Install any needed extensions
+RUN docker-php-ext-install pdo pdo_mysql
+
+# Expose port 80
+EXPOSE 80
+
+# Start Apache server
+CMD ["apache2-foreground"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO games
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: games
+
+games-website:
+  defines: runnable
+  metadata:
+    name: games-website
+    description: A PHP web application serving as a games website.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    games-website:
+      image: env-3251.registry.local/games-website:master-166d8c7
+      build: .
+      dockerfile: Dockerfile.games-website
+  services:
+    http:
+      description: HTTP port for web traffic
+      container: games-website
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - games/games-website


### PR DESCRIPTION
# Containerization and Deployment Configuration for Games Website

In this PR, I have containerized the PHP web application 'games-website' and written the necessary deployment configuration. The application is straightforward, with its source code located in the `_build/src/` directory, and does not rely on any external services like databases or external PHP libraries.

### Dockerfile Creation
I created a Dockerfile named `Dockerfile.games-website` from scratch as it was not present in the repository. This Dockerfile is set up to serve the PHP application using Apache, and it copies the source code to the appropriate directory, installs necessary PHP extensions, exposes port 80, and starts the Apache server. The logs from the container indicate that Apache started normally, and the warning about the server's fully qualified domain name is a common non-critical message.

### Monk.io Configuration
I added a `monk.yaml` file containing the Monk configuration and a `MANIFEST` file listing all files with Monk configurations. The Dockerfile for the games-website service exposes port 80 and uses the `php:7.4-apache` base image. No environment variables are set in the Dockerfile, and after checking the source code and configuration files, it seems that the games-website service does not require any environment variables.

### Finalization and Observations
The service does not have any connections to other services and exposes port 80 for HTTP traffic. The analysis of the service is complete, and all required information has been determined and provided. There are no further actions to continue with for this service.

To proceed, simply merge this PR, and the application will be re-deployed on each subsequent push. If there are other services in the ecosystem that 'games-website' needs to connect to or any variables that need to be set, additional information will be required to configure those connections or settings.