### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.attogram-games-website-builder
+++ b/Dockerfile.attogram-games-website-builder
@@ -1,0 +1,16 @@
+FROM php:7.4-apache
+
+# Copy the application files to the container
+COPY _build/ /var/www/html/
+
+# Expose port 80
+EXPOSE 80
+
+# Set the working directory to the Apache web root
+WORKDIR /var/www/html
+
+# Install any needed extensions
+RUN docker-php-ext-install pdo pdo_mysql
+
+# Start Apache in the foreground
+CMD ["apache2-foreground"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO games
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: games
+
+attogram-games-website-builder:
+  defines: runnable
+  metadata:
+    name: attogram-games-website-builder
+    description: PHP-based static site generator for a games website.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    attogram-games-website-builder:
+      image: env-4297.registry.local/attogram-games-website-builder:master-166d8c7
+      build: .
+      dockerfile: Dockerfile.attogram-games-website-builder
+  services:
+    http:
+      description: Standard HTTP port for web traffic
+      container: attogram-games-website-builder
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - games/attogram-games-website-builder


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Attogram Games Website Builder

## Summary of Changes
I have successfully containerized the Attogram Games Website Builder application and prepared it for deployment. Here's a brief overview of the work done:

- **Dockerfile Creation**: I created a Dockerfile named `Dockerfile.attogram-games-website-builder` which sets up a PHP 7.4 Apache environment, copies the application files from the `_build` directory to the Apache web root, and exposes port 80.
- **Monk.io Configuration**: Added a `monk.yaml` file containing the Monk configuration and a `MANIFEST` file listing all files with Monk configurations.
- **Service Analysis**: Confirmed that the application is a PHP-based static site generator that does not require any external services like databases. It is self-contained and only needs a PHP runtime environment.
- **Environment Variables**: No environment variables or connections to other services are required for this application. It operates as a standalone service.

## Instructions for Deployment
The application is ready for deployment. Upon merging this PR, the application will be re-deployed on each subsequent push. Here are the steps to proceed:

1. Review the changes and the `Dockerfile.attogram-games-website-builder` to ensure everything is in order.
2. Merge the PR to trigger the deployment process.
3. The application should now be accessible on port 80.

## Notes on Service Configuration
- The application exposes port 80 for HTTP traffic, which is standard for web applications.
- The Dockerfile and Monk configuration are set up to handle the PHP environment without the need for additional services or environment variables.

Please review the changes and proceed with the merge if everything is satisfactory. The application should operate normally once deployed.